### PR TITLE
Remove Gulmira team references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,15 @@
 # Startum Kids Landing Page
 
-*Automatically synced with your [v0.app](https://v0.app) deployments*
-
-[![Deployed on Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=for-the-badge&logo=vercel)](https://vercel.com/gulmirabektas1-2162s-projects/v0-ai-progress)
-[![Built with v0](https://img.shields.io/badge/Built%20with-v0.app-black?style=for-the-badge)](https://v0.app/chat/projects/gTnwGOrCqum)
+This repository previously mirrored a deployment owned by Gulmira's Vercel team. The
+automated links have been removed so it can now operate as an independent project.
 
 ## Overview
 
-This repository will stay in sync with your deployed chats on [v0.app](https://v0.app).
-Any changes you make to your deployed app will be automatically pushed to this repository from [v0.app](https://v0.app).
+The app is built with Next.js. You can run it locally with `pnpm dev` (or your
+preferred Node.js package manager) and deploy it using your own hosting setup.
 
-## Deployment
+## Getting started
 
-Your project is live at:
-
-**[https://vercel.com/gulmirabektas1-2162s-projects/v0-ai-progress](https://vercel.com/gulmirabektas1-2162s-projects/v0-ai-progress)**
-
-## Build your app
-
-Continue building your app on:
-
-**[https://v0.app/chat/projects/gTnwGOrCqum](https://v0.app/chat/projects/gTnwGOrCqum)**
-
-## How It Works
-
-1. Create and modify your project using [v0.app](https://v0.app)
-2. Deploy your chats from the v0 interface
-3. Changes are automatically pushed to this repository
-4. Vercel deploys the latest version from this repository
+1. Install dependencies with `pnpm install`.
+2. Start the development server with `pnpm dev`.
+3. Update this README with any deployment details that match your new workflow.


### PR DESCRIPTION
## Summary
- remove the badges and deployment links that pointed to Gulmira's Vercel team
- add general guidance for running the Next.js app locally and documenting new deployments

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8ffbfc5fc832ba0e75f9b628d218a