### PR TITLE
Add multi-language support with language switcher

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,15 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
+
+import { LanguageProvider } from "@/components/language-provider"
+import { translations } from "@/lib/translations"
+
 import "./globals.css"
 
 export const metadata: Metadata = {
-  title: "Startum Kids — твой старт в будущее с ИИ",
-  description:
-    "Современная мини-школа для детей 8+ лет. Развиваем креативность и цифровые навыки через практику с искусственным интеллектом.",
+  title: translations.ru.metadata.title,
+  description: translations.ru.metadata.description,
   generator: "v0.app",
 }
 
@@ -19,8 +22,10 @@ export default function RootLayout({
   return (
     <html lang="ru">
       <body className="font-sans antialiased">
-        <Suspense fallback={null}>{children}</Suspense>
-        <Analytics />
+        <LanguageProvider>
+          <Suspense fallback={null}>{children}</Suspense>
+          <Analytics />
+        </LanguageProvider>
       </body>
     </html>
   )

--- a/components/about-section.tsx
+++ b/components/about-section.tsx
@@ -1,50 +1,42 @@
+"use client"
+
 import { Card } from "@/components/ui/card"
 import { Target, Users, Lightbulb } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function AboutSection() {
+  const t = useTranslations()
+  const icons = [Target, Users, Lightbulb]
+  const accentClasses = ["bg-primary/10", "bg-secondary/10", "bg-accent/10"]
+  const iconColors = ["text-primary", "text-secondary", "text-accent-foreground"]
+
   return (
     <section id="about" className="py-20 bg-muted/30">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-            О школе <span className="text-primary">Startum Kids</span>
+            {t.about.heading} <span className="text-primary">{t.about.highlight}</span>
           </h2>
 
-          <p className="text-xl text-muted-foreground mb-12 max-w-3xl mx-auto text-balance">
-            Мы создали уникальную образовательную среду, где дети изучают будущее уже сегодня. Наша миссия — развивать
-            детей через практику с ИИ-инструментами, формируя креативность и цифровые навыки XXI века.
-          </p>
+          <p className="text-xl text-muted-foreground mb-12 max-w-3xl mx-auto text-balance">{t.about.description}</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <Card className="p-6 text-center hover:shadow-lg transition-shadow">
-              <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Target className="w-8 h-8 text-primary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-3">Наша цель</h3>
-              <p className="text-muted-foreground">
-                Подготовить детей к будущему, где ИИ станет неотъемлемой частью жизни и работы
-              </p>
-            </Card>
+            {t.about.cards.map((card, index) => {
+              const Icon = icons[index] ?? Target
 
-            <Card className="p-6 text-center hover:shadow-lg transition-shadow">
-              <div className="w-16 h-16 bg-secondary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Users className="w-8 h-8 text-secondary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-3">Наш подход</h3>
-              <p className="text-muted-foreground">
-                Обучение в мини-группах с индивидуальным подходом к каждому ребенку
-              </p>
-            </Card>
-
-            <Card className="p-6 text-center hover:shadow-lg transition-shadow">
-              <div className="w-16 h-16 bg-accent/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Lightbulb className="w-8 h-8 text-accent-foreground" />
-              </div>
-              <h3 className="text-xl font-semibold mb-3">Наш результат</h3>
-              <p className="text-muted-foreground">
-                Уверенные в себе дети, готовые творить и создавать с помощью современных технологий
-              </p>
-            </Card>
+              return (
+                <Card key={card.title} className="p-6 text-center hover:shadow-lg transition-shadow">
+                  <div
+                    className={`w-16 h-16 ${accentClasses[index] ?? "bg-primary/10"} rounded-full flex items-center justify-center mx-auto mb-4`}
+                  >
+                    <Icon className={`w-8 h-8 ${iconColors[index] ?? "text-primary"}`} />
+                  </div>
+                  <h3 className="text-xl font-semibold mb-3">{card.title}</h3>
+                  <p className="text-muted-foreground">{card.description}</p>
+                </Card>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/components/cta-section.tsx
+++ b/components/cta-section.tsx
@@ -1,20 +1,21 @@
+"use client"
+
 import { Button } from "@/components/ui/button"
 import { Rocket, ArrowRight } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function CtaSection() {
+  const t = useTranslations()
+  const bulletColors = ["bg-primary", "bg-secondary", "bg-accent"]
+
   return (
     <section className="py-20 bg-gradient-to-br from-primary/10 via-secondary/5 to-accent/10 relative overflow-hidden">
       {/* Background Elements */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute top-10 left-10 w-32 h-32 bg-primary/10 rounded-full animate-float"></div>
-        <div
-          className="absolute bottom-10 right-10 w-24 h-24 bg-secondary/10 rounded-full animate-float"
-          style={{ animationDelay: "1s" }}
-        ></div>
-        <div
-          className="absolute top-1/2 left-1/4 w-16 h-16 bg-accent/10 rounded-full animate-float"
-          style={{ animationDelay: "2s" }}
-        ></div>
+        <div className="absolute bottom-10 right-10 w-24 h-24 bg-secondary/10 rounded-full animate-float" style={{ animationDelay: "1s" }}></div>
+        <div className="absolute top-1/2 left-1/4 w-16 h-16 bg-accent/10 rounded-full animate-float" style={{ animationDelay: "2s" }}></div>
       </div>
 
       <div className="container mx-auto px-4 relative z-10">
@@ -26,21 +27,16 @@ export function CtaSection() {
           </div>
 
           <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-            <span className="text-primary">Startum Kids</span> —<br />
-            начни путь в будущее уже сегодня
+            <span className="text-primary">{t.cta.headingPrefix}</span> <span>{t.cta.headingHighlight}</span>
+            <br />
+            {t.cta.headingSuffix}
           </h2>
 
-          <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto text-balance">
-            Дай своему ребенку преимущество в мире технологий. Запишись на бесплатное пробное занятие и убедись в
-            эффективности нашего подхода.
-          </p>
+          <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto text-balance">{t.cta.description}</p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8">
-            <Button
-              size="lg"
-              className="bg-primary hover:bg-primary/90 text-white font-semibold px-8 py-4 text-lg group"
-            >
-              Записаться на пробное занятие
+            <Button size="lg" className="bg-primary hover:bg-primary/90 text-white font-semibold px-8 py-4 text-lg group">
+              {t.cta.primaryAction}
               <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
             </Button>
             <Button
@@ -48,23 +44,17 @@ export function CtaSection() {
               variant="outline"
               className="border-2 border-secondary text-secondary hover:bg-secondary hover:text-white font-semibold px-8 py-4 text-lg bg-transparent"
             >
-              Задать вопрос
+              {t.cta.secondaryAction}
             </Button>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-2xl mx-auto text-sm text-muted-foreground">
-            <div className="flex items-center justify-center gap-2">
-              <div className="w-2 h-2 bg-primary rounded-full"></div>
-              <span>Бесплатное пробное занятие</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <div className="w-2 h-2 bg-secondary rounded-full"></div>
-              <span>Без долгосрочных обязательств</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <div className="w-2 h-2 bg-accent rounded-full"></div>
-              <span>Индивидуальный подход</span>
-            </div>
+            {t.cta.highlights.map((highlight, index) => (
+              <div key={highlight} className="flex items-center justify-center gap-2">
+                <div className={`w-2 h-2 ${bulletColors[index] ?? bulletColors[0]} rounded-full`}></div>
+                <span>{highlight}</span>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,6 +1,12 @@
+"use client"
+
 import { Mail, Phone, MapPin, Instagram, Youtube, Send } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function Footer() {
+  const t = useTranslations()
+
   return (
     <footer id="contacts" className="bg-foreground text-background py-16">
       <div className="container mx-auto px-4">
@@ -10,30 +16,30 @@ export function Footer() {
             <div className="lg:col-span-2">
               <div className="flex items-center gap-2 mb-4">
                 <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
-                  <span className="text-white font-bold text-lg">SK</span>
+                  <span className="text-white font-bold text-lg">{t.header.brandInitials}</span>
                 </div>
-                <span className="text-xl font-bold">Startum Kids</span>
+                <span className="text-xl font-bold">{t.header.brandName}</span>
               </div>
-              <p className="text-background/70 mb-6 max-w-md">
-                Современная мини-школа для детей 8+ лет. Развиваем креативность и цифровые навыки через практику с
-                искусственным интеллектом.
-              </p>
+              <p className="text-background/70 mb-6 max-w-md">{t.footer.description}</p>
               <div className="flex gap-4">
                 <a
                   href="#"
                   className="w-10 h-10 bg-background/10 hover:bg-primary rounded-lg flex items-center justify-center transition-colors"
+                  aria-label="Instagram"
                 >
                   <Instagram className="w-5 h-5" />
                 </a>
                 <a
                   href="#"
                   className="w-10 h-10 bg-background/10 hover:bg-primary rounded-lg flex items-center justify-center transition-colors"
+                  aria-label="YouTube"
                 >
                   <Youtube className="w-5 h-5" />
                 </a>
                 <a
                   href="#"
                   className="w-10 h-10 bg-background/10 hover:bg-primary rounded-lg flex items-center justify-center transition-colors"
+                  aria-label="Telegram"
                 >
                   <Send className="w-5 h-5" />
                 </a>
@@ -42,31 +48,31 @@ export function Footer() {
 
             {/* Quick Links */}
             <div>
-              <h3 className="text-lg font-semibold mb-4">Быстрые ссылки</h3>
+              <h3 className="text-lg font-semibold mb-4">{t.footer.quickLinksHeading}</h3>
               <ul className="space-y-2">
                 <li>
                   <a href="#about" className="text-background/70 hover:text-background transition-colors">
-                    О школе
+                    {t.footer.quickLinks.about}
                   </a>
                 </li>
                 <li>
                   <a href="#programs" className="text-background/70 hover:text-background transition-colors">
-                    Программы
+                    {t.footer.quickLinks.programs}
                   </a>
                 </li>
                 <li>
                   <a href="#advantages" className="text-background/70 hover:text-background transition-colors">
-                    Преимущества
+                    {t.footer.quickLinks.advantages}
                   </a>
                 </li>
                 <li>
                   <a href="#" className="text-background/70 hover:text-background transition-colors">
-                    Расписание
+                    {t.footer.quickLinks.schedule}
                   </a>
                 </li>
                 <li>
                   <a href="#" className="text-background/70 hover:text-background transition-colors">
-                    Цены
+                    {t.footer.quickLinks.pricing}
                   </a>
                 </li>
               </ul>
@@ -74,19 +80,19 @@ export function Footer() {
 
             {/* Contact Info */}
             <div>
-              <h3 className="text-lg font-semibold mb-4">Контакты</h3>
+              <h3 className="text-lg font-semibold mb-4">{t.footer.contactsHeading}</h3>
               <div className="space-y-3">
                 <div className="flex items-center gap-3">
                   <Phone className="w-5 h-5 text-primary" />
-                  <span className="text-background/70">+7 (999) 123-45-67</span>
+                  <span className="text-background/70">{t.footer.phone}</span>
                 </div>
                 <div className="flex items-center gap-3">
                   <Mail className="w-5 h-5 text-primary" />
-                  <span className="text-background/70">info@startumkids.ru</span>
+                  <span className="text-background/70">{t.footer.email}</span>
                 </div>
                 <div className="flex items-start gap-3">
                   <MapPin className="w-5 h-5 text-primary mt-0.5" />
-                  <span className="text-background/70">г. Москва, ул. Инновационная, д. 42</span>
+                  <span className="text-background/70">{t.footer.address}</span>
                 </div>
               </div>
             </div>
@@ -94,13 +100,13 @@ export function Footer() {
 
           {/* Bottom Bar */}
           <div className="border-t border-background/20 pt-8 flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-background/70 text-sm">© 2025 Startum Kids. Все права защищены.</p>
+            <p className="text-background/70 text-sm">{t.footer.copyright}</p>
             <div className="flex gap-6 text-sm">
               <a href="#" className="text-background/70 hover:text-background transition-colors">
-                Политика конфиденциальности
+                {t.footer.privacy}
               </a>
               <a href="#" className="text-background/70 hover:text-background transition-colors">
-                Пользовательское соглашение
+                {t.footer.terms}
               </a>
             </div>
           </div>

--- a/components/format-section.tsx
+++ b/components/format-section.tsx
@@ -1,23 +1,12 @@
+"use client"
+
 import { Users, Zap, Trophy } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function FormatSection() {
-  const features = [
-    {
-      icon: Users,
-      title: "Мини-группы",
-      description: "До 6 детей в группе для максимального внимания каждому ученику",
-    },
-    {
-      icon: Zap,
-      title: "Практика",
-      description: "100% практических занятий с реальными ИИ-инструментами",
-    },
-    {
-      icon: Trophy,
-      title: "Результат",
-      description: "Каждый ребенок создает собственный проект к концу курса",
-    },
-  ]
+  const t = useTranslations()
+  const icons = [Users, Zap, Trophy]
 
   return (
     <section className="py-20">
@@ -25,28 +14,30 @@ export function FormatSection() {
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-              Формат <span className="text-secondary">обучения</span>
+              {t.format.heading} <span className="text-secondary">{t.format.highlight}</span>
             </h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">
-              Современный подход к образованию с фокусом на практические результаты
-            </p>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">{t.format.description}</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <div key={index} className="text-center group">
-                <div className="relative mb-8">
-                  <div className="w-24 h-24 bg-gradient-to-br from-primary/10 via-secondary/10 to-accent/10 rounded-3xl flex items-center justify-center mx-auto group-hover:scale-110 transition-transform duration-300">
-                    <feature.icon className="w-12 h-12 text-primary" />
+            {t.format.features.map((feature, index) => {
+              const Icon = icons[index] ?? Users
+
+              return (
+                <div key={feature.title} className="text-center group">
+                  <div className="relative mb-8">
+                    <div className="w-24 h-24 bg-gradient-to-br from-primary/10 via-secondary/10 to-accent/10 rounded-3xl flex items-center justify-center mx-auto group-hover:scale-110 transition-transform duration-300">
+                      <Icon className="w-12 h-12 text-primary" />
+                    </div>
+                    <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 blur-xl"></div>
                   </div>
-                  <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 blur-xl"></div>
+
+                  <h3 className="text-2xl font-semibold mb-4 text-foreground">{feature.title}</h3>
+
+                  <p className="text-muted-foreground text-lg text-balance">{feature.description}</p>
                 </div>
-
-                <h3 className="text-2xl font-semibold mb-4 text-foreground">{feature.title}</h3>
-
-                <p className="text-muted-foreground text-lg text-balance">{feature.description}</p>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,8 +4,12 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Menu, X } from "lucide-react"
 
+import { LanguageSwitcher } from "@/components/language-switcher"
+import { useTranslations } from "@/components/language-provider"
+
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const t = useTranslations()
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-border">
@@ -14,30 +18,30 @@ export function Header() {
           {/* Logo */}
           <div className="flex items-center gap-2">
             <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
-              <span className="text-white font-bold text-lg">SK</span>
+              <span className="text-white font-bold text-lg">{t.header.brandInitials}</span>
             </div>
-            <span className="text-xl font-bold text-foreground">Startum Kids</span>
+            <span className="text-xl font-bold text-foreground">{t.header.brandName}</span>
           </div>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center gap-8">
             <a href="#about" className="text-muted-foreground hover:text-foreground transition-colors">
-              О школе
+              {t.header.nav.about}
             </a>
             <a href="#programs" className="text-muted-foreground hover:text-foreground transition-colors">
-              Программы
+              {t.header.nav.programs}
             </a>
             <a href="#advantages" className="text-muted-foreground hover:text-foreground transition-colors">
-              Преимущества
+              {t.header.nav.advantages}
             </a>
             <a href="#contacts" className="text-muted-foreground hover:text-foreground transition-colors">
-              Контакты
+              {t.header.nav.contacts}
             </a>
           </nav>
 
-          {/* CTA Button */}
-          <div className="hidden md:block">
-            <Button className="bg-primary hover:bg-primary/90 text-white font-medium">Записаться</Button>
+          <div className="hidden md:flex items-center gap-3">
+            <LanguageSwitcher />
+            <Button className="bg-primary hover:bg-primary/90 text-white font-medium">{t.header.cta}</Button>
           </div>
 
           {/* Mobile Menu Button */}
@@ -50,19 +54,22 @@ export function Header() {
         {isMenuOpen && (
           <nav className="md:hidden mt-4 pb-4 border-t border-border pt-4">
             <div className="flex flex-col gap-4">
+              <LanguageSwitcher />
               <a href="#about" className="text-muted-foreground hover:text-foreground transition-colors">
-                О школе
+                {t.header.nav.about}
               </a>
               <a href="#programs" className="text-muted-foreground hover:text-foreground transition-colors">
-                Программы
+                {t.header.nav.programs}
               </a>
               <a href="#advantages" className="text-muted-foreground hover:text-foreground transition-colors">
-                Преимущества
+                {t.header.nav.advantages}
               </a>
               <a href="#contacts" className="text-muted-foreground hover:text-foreground transition-colors">
-                Контакты
+                {t.header.nav.contacts}
               </a>
-              <Button className="bg-primary hover:bg-primary/90 text-white font-medium w-full mt-2">Записаться</Button>
+              <Button className="bg-primary hover:bg-primary/90 text-white font-medium w-full mt-2">
+                {t.header.cta}
+              </Button>
             </div>
           </nav>
         )}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -1,7 +1,13 @@
+"use client"
+
 import { Button } from "@/components/ui/button"
 import { Sparkles, Zap, Brain } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function HeroSection() {
+  const t = useTranslations()
+
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-primary/10 via-secondary/5 to-accent/10">
       {/* Background Elements */}
@@ -28,7 +34,7 @@ export function HeroSection() {
             <div className="relative">
               <img
                 src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/%D0%BD%D0%B0%D1%88%20%D0%B1%D0%BE%D1%82.jpg-pEshDjyZgmSpXSjSnxjac8lEBrKI2P.jpeg"
-                alt="Startum Kids AI Robot"
+                alt={t.hero.imageAlt}
                 className="w-48 h-48 object-contain animate-float"
               />
               <div className="absolute -top-2 -right-2 w-8 h-8 bg-accent rounded-full flex items-center justify-center animate-pulse-glow">
@@ -39,25 +45,23 @@ export function HeroSection() {
 
           {/* Main Heading */}
           <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-balance mb-6">
-            <span className="text-foreground">Startum Kids —</span>
+            <span className="text-foreground">{t.hero.titlePrefix}</span>
             <br />
             <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
-              твой старт в будущее
+              {t.hero.titleHighlight}
             </span>
             <br />
-            <span className="text-foreground">с искусственным интеллектом</span>
+            <span className="text-foreground">{t.hero.titleSuffix}</span>
           </h1>
 
           {/* Subtitle */}
-          <p className="text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto text-balance">
-            Развиваем детей 8+ лет через практику с ИИ-инструментами, креативность и современные цифровые навыки
-          </p>
+          <p className="text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto text-balance">{t.hero.subtitle}</p>
 
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
             <Button size="lg" className="bg-primary hover:bg-primary/90 text-white font-semibold px-8 py-4 text-lg">
               <Zap className="w-5 h-5 mr-2" />
-              Попробовать бесплатно
+              {t.hero.primaryAction}
             </Button>
             <Button
               size="lg"
@@ -65,24 +69,22 @@ export function HeroSection() {
               className="border-2 border-secondary text-secondary hover:bg-secondary hover:text-white font-semibold px-8 py-4 text-lg bg-transparent"
             >
               <Brain className="w-5 h-5 mr-2" />
-              Узнать больше
+              {t.hero.secondaryAction}
             </Button>
           </div>
 
           {/* Features Preview */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-3xl mx-auto">
-            <div className="flex items-center justify-center gap-2 text-muted-foreground">
-              <div className="w-2 h-2 bg-primary rounded-full"></div>
-              <span>Мини-группы до 6 детей</span>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-muted-foreground">
-              <div className="w-2 h-2 bg-secondary rounded-full"></div>
-              <span>100% практические занятия</span>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-muted-foreground">
-              <div className="w-2 h-2 bg-accent rounded-full"></div>
-              <span>Реальные проекты с ИИ</span>
-            </div>
+            {t.hero.features.map((feature, index) => {
+              const colors = ["bg-primary", "bg-secondary", "bg-accent"]
+
+              return (
+                <div key={feature} className="flex items-center justify-center gap-2 text-muted-foreground">
+                  <div className={`w-2 h-2 rounded-full ${colors[index] ?? "bg-primary"}`}></div>
+                  <span>{feature}</span>
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
+
+import { translations, type Language, type TranslationContent } from "@/lib/translations"
+
+type LanguageContextValue = {
+  language: Language
+  setLanguage: (language: Language) => void
+  t: TranslationContent
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined)
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Language>("ru")
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const stored = window.localStorage.getItem("preferredLanguage") as Language | null
+    if (stored && stored in translations) {
+      setLanguage(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem("preferredLanguage", language)
+  }, [language])
+
+  useEffect(() => {
+    document.documentElement.lang = language
+    document.title = translations[language].metadata.title
+
+    const metaDescription = document.querySelector('meta[name="description"]')
+    if (metaDescription) {
+      metaDescription.setAttribute("content", translations[language].metadata.description)
+    }
+  }, [language])
+
+  const value = useMemo<LanguageContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      t: translations[language],
+    }),
+    [language]
+  )
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider")
+  }
+
+  return { language: context.language, setLanguage: context.setLanguage }
+}
+
+export function useTranslations() {
+  const context = useContext(LanguageContext)
+
+  if (!context) {
+    throw new Error("useTranslations must be used within a LanguageProvider")
+  }
+
+  return context.t
+}

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import clsx from "clsx"
+
+import { useLanguage } from "@/components/language-provider"
+import type { Language } from "@/lib/translations"
+
+const options: Array<{ value: Language; label: string }> = [
+  { value: "ru", label: "Рус" },
+  { value: "en", label: "Eng" },
+  { value: "kk", label: "Қаз" },
+]
+
+export function LanguageSwitcher() {
+  const { language, setLanguage } = useLanguage()
+
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-border bg-white/70 p-1 text-sm shadow-sm">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => setLanguage(option.value)}
+          className={clsx(
+            "rounded-full px-3 py-1 transition-colors",
+            language === option.value
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-muted"
+          )}
+          aria-pressed={language === option.value}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/programs-section.tsx
+++ b/components/programs-section.tsx
@@ -1,37 +1,15 @@
+"use client"
+
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { User, Film, GraduationCap, Clock, Users, Star } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function ProgramsSection() {
-  const programs = [
-    {
-      icon: User,
-      title: "Создай персонажа с ИИ",
-      description: "Дети учатся создавать уникальных персонажей с помощью ИИ-генераторов изображений",
-      duration: "4 недели",
-      age: "8-12 лет",
-      level: "Начинающий",
-      color: "from-primary/20 to-primary/10",
-    },
-    {
-      icon: Film,
-      title: "Мультфильмы с ИИ",
-      description: "Создание коротких анимационных роликов с использованием ИИ-инструментов",
-      duration: "6 недель",
-      age: "10-14 лет",
-      level: "Продвинутый",
-      color: "from-secondary/20 to-secondary/10",
-    },
-    {
-      icon: GraduationCap,
-      title: "ИИ-помощник в учёбе",
-      description: "Изучаем, как ИИ может помочь в выполнении домашних заданий и изучении новых тем",
-      duration: "3 недели",
-      age: "8-16 лет",
-      level: "Для всех",
-      color: "from-accent/20 to-accent/10",
-    },
-  ]
+  const t = useTranslations()
+  const icons = [User, Film, GraduationCap]
+  const gradients = ["from-primary/20 to-primary/10", "from-secondary/20 to-secondary/10", "from-accent/20 to-accent/10"]
 
   return (
     <section id="programs" className="py-20 bg-muted/30">
@@ -39,44 +17,46 @@ export function ProgramsSection() {
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-              Наши <span className="text-primary">программы</span>
+              {t.programs.heading} <span className="text-primary">{t.programs.highlight}</span>
             </h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">
-              Практические курсы, где дети создают реальные проекты с помощью ИИ-инструментов
-            </p>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">{t.programs.description}</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {programs.map((program, index) => (
-              <Card key={index} className="p-6 hover:shadow-xl transition-all duration-300 group">
-                <div
-                  className={`w-16 h-16 bg-gradient-to-br ${program.color} rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300`}
-                >
-                  <program.icon className="w-8 h-8 text-primary" />
-                </div>
+            {t.programs.items.map((program, index) => {
+              const Icon = icons[index] ?? User
 
-                <h3 className="text-xl font-semibold mb-3 text-foreground">{program.title}</h3>
-
-                <p className="text-muted-foreground mb-6 text-balance">{program.description}</p>
-
-                <div className="space-y-3 mb-6">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Clock className="w-4 h-4" />
-                    <span>{program.duration}</span>
+              return (
+                <Card key={program.title} className="p-6 hover:shadow-xl transition-all duration-300 group">
+                  <div
+                    className={`w-16 h-16 bg-gradient-to-br ${gradients[index] ?? gradients[0]} rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300`}
+                  >
+                    <Icon className="w-8 h-8 text-primary" />
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Users className="w-4 h-4" />
-                    <span>{program.age}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Star className="w-4 h-4" />
-                    <span>{program.level}</span>
-                  </div>
-                </div>
 
-                <Button className="w-full bg-primary hover:bg-primary/90 text-white">Записаться на курс</Button>
-              </Card>
-            ))}
+                  <h3 className="text-xl font-semibold mb-3 text-foreground">{program.title}</h3>
+
+                  <p className="text-muted-foreground mb-6 text-balance">{program.description}</p>
+
+                  <div className="space-y-3 mb-6">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Clock className="w-4 h-4" />
+                      <span>{program.duration}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Users className="w-4 h-4" />
+                      <span>{program.age}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Star className="w-4 h-4" />
+                      <span>{program.level}</span>
+                    </div>
+                  </div>
+
+                  <Button className="w-full bg-primary hover:bg-primary/90 text-white">{t.programs.cta}</Button>
+                </Card>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/components/testimonials-section.tsx
+++ b/components/testimonials-section.tsx
@@ -1,30 +1,12 @@
+"use client"
+
 import { Card } from "@/components/ui/card"
 import { Star, Quote } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function TestimonialsSection() {
-  const testimonials = [
-    {
-      name: "Анна Петрова",
-      role: "Мама Максима, 10 лет",
-      content:
-        "Максим в восторге от занятий! Теперь он создает своих персонажей и даже помогает мне с презентациями для работы. Спасибо Startum Kids за такой современный подход к обучению.",
-      rating: 5,
-    },
-    {
-      name: "Дмитрий Козлов",
-      role: "Папа Софии, 12 лет",
-      content:
-        "София всегда была творческой, но здесь она научилась воплощать свои идеи с помощью ИИ. Теперь она мечтает стать дизайнером и уже создает потрясающие проекты.",
-      rating: 5,
-    },
-    {
-      name: "Елена Смирнова",
-      role: "Мама Артема, 9 лет",
-      content:
-        "Артем стал более уверенным в себе и начал интересоваться технологиями. Преподаватели умеют найти подход к каждому ребенку. Очень рекомендую!",
-      rating: 5,
-    },
-  ]
+  const t = useTranslations()
 
   return (
     <section className="py-20 bg-muted/30">
@@ -32,16 +14,14 @@ export function TestimonialsSection() {
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-              Что говорят <span className="text-primary">родители</span>
+              {t.testimonials.heading} <span className="text-primary">{t.testimonials.highlight}</span>
             </h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">
-              Отзывы семей, которые уже оценили качество нашего обучения
-            </p>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">{t.testimonials.description}</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {testimonials.map((testimonial, index) => (
-              <Card key={index} className="p-6 hover:shadow-lg transition-shadow relative">
+            {t.testimonials.entries.map((testimonial) => (
+              <Card key={testimonial.name} className="p-6 hover:shadow-lg transition-shadow relative">
                 <Quote className="w-8 h-8 text-primary/20 absolute top-4 right-4" />
 
                 <div className="flex items-center gap-1 mb-4">

--- a/components/why-important-section.tsx
+++ b/components/why-important-section.tsx
@@ -1,28 +1,12 @@
+"use client"
+
 import { Rocket, Palette, Cpu, Trophy } from "lucide-react"
 
+import { useTranslations } from "@/components/language-provider"
+
 export function WhyImportantSection() {
-  const benefits = [
-    {
-      icon: Rocket,
-      title: "Навыки будущего",
-      description: "Изучение ИИ-инструментов, которые будут востребованы в ближайшие 10-20 лет",
-    },
-    {
-      icon: Palette,
-      title: "Креативность",
-      description: "Развитие творческого мышления через создание уникальных проектов с ИИ",
-    },
-    {
-      icon: Cpu,
-      title: "Работа с технологиями",
-      description: "Практические навыки использования современных цифровых инструментов",
-    },
-    {
-      icon: Trophy,
-      title: "Уверенность в себе",
-      description: "Повышение самооценки через достижение реальных результатов в проектах",
-    },
-  ]
+  const t = useTranslations()
+  const icons = [Rocket, Palette, Cpu, Trophy]
 
   return (
     <section id="advantages" className="py-20">
@@ -30,26 +14,28 @@ export function WhyImportantSection() {
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-6 text-balance">
-              Почему это <span className="text-secondary">важно</span>
+              {t.whyImportant.heading} <span className="text-secondary">{t.whyImportant.highlight}</span>
             </h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">
-              В мире, где ИИ меняет все сферы жизни, важно дать детям преимущество уже сегодня
-            </p>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-balance">{t.whyImportant.description}</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-            {benefits.map((benefit, index) => (
-              <div key={index} className="text-center group">
-                <div className="relative mb-6">
-                  <div className="w-20 h-20 bg-gradient-to-br from-primary/20 to-secondary/20 rounded-2xl flex items-center justify-center mx-auto group-hover:scale-110 transition-transform duration-300">
-                    <benefit.icon className="w-10 h-10 text-primary" />
+            {t.whyImportant.benefits.map((benefit, index) => {
+              const Icon = icons[index] ?? Rocket
+
+              return (
+                <div key={benefit.title} className="text-center group">
+                  <div className="relative mb-6">
+                    <div className="w-20 h-20 bg-gradient-to-br from-primary/20 to-secondary/20 rounded-2xl flex items-center justify-center mx-auto group-hover:scale-110 transition-transform duration-300">
+                      <Icon className="w-10 h-10 text-primary" />
+                    </div>
+                    <div className="absolute -top-2 -right-2 w-6 h-6 bg-accent rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                   </div>
-                  <div className="absolute -top-2 -right-2 w-6 h-6 bg-accent rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                  <h3 className="text-xl font-semibold mb-3 text-foreground">{benefit.title}</h3>
+                  <p className="text-muted-foreground text-balance">{benefit.description}</p>
                 </div>
-                <h3 className="text-xl font-semibold mb-3 text-foreground">{benefit.title}</h3>
-                <p className="text-muted-foreground text-balance">{benefit.description}</p>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </div>

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -1,0 +1,641 @@
+export type Language = "ru" | "en" | "kk"
+
+export type TranslationContent = {
+  metadata: {
+    title: string
+    description: string
+  }
+  header: {
+    brandInitials: string
+    brandName: string
+    nav: {
+      about: string
+      programs: string
+      advantages: string
+      contacts: string
+    }
+    cta: string
+  }
+  hero: {
+    imageAlt: string
+    titlePrefix: string
+    titleHighlight: string
+    titleSuffix: string
+    subtitle: string
+    primaryAction: string
+    secondaryAction: string
+    features: string[]
+  }
+  about: {
+    heading: string
+    highlight: string
+    description: string
+    cards: Array<{
+      title: string
+      description: string
+    }>
+  }
+  whyImportant: {
+    heading: string
+    highlight: string
+    description: string
+    benefits: Array<{
+      title: string
+      description: string
+    }>
+  }
+  programs: {
+    heading: string
+    highlight: string
+    description: string
+    items: Array<{
+      title: string
+      description: string
+      duration: string
+      age: string
+      level: string
+    }>
+    cta: string
+  }
+  format: {
+    heading: string
+    highlight: string
+    description: string
+    features: Array<{
+      title: string
+      description: string
+    }>
+  }
+  testimonials: {
+    heading: string
+    highlight: string
+    description: string
+    entries: Array<{
+      name: string
+      role: string
+      content: string
+      rating: number
+    }>
+  }
+  cta: {
+    headingPrefix: string
+    headingHighlight: string
+    headingSuffix: string
+    description: string
+    primaryAction: string
+    secondaryAction: string
+    highlights: string[]
+  }
+  footer: {
+    description: string
+    quickLinksHeading: string
+    quickLinks: {
+      about: string
+      programs: string
+      advantages: string
+      schedule: string
+      pricing: string
+    }
+    contactsHeading: string
+    phone: string
+    email: string
+    address: string
+    copyright: string
+    privacy: string
+    terms: string
+  }
+}
+
+export const translations: Record<Language, TranslationContent> = {
+  ru: {
+    metadata: {
+      title: "Startum Kids — твой старт в будущее с ИИ",
+      description:
+        "Современная мини-школа для детей 8+ лет. Развиваем креативность и цифровые навыки через практику с искусственным интеллектом.",
+    },
+    header: {
+      brandInitials: "SK",
+      brandName: "Startum Kids",
+      nav: {
+        about: "О школе",
+        programs: "Программы",
+        advantages: "Преимущества",
+        contacts: "Контакты",
+      },
+      cta: "Записаться",
+    },
+    hero: {
+      imageAlt: "Startum Kids — образовательный робот",
+      titlePrefix: "Startum Kids —",
+      titleHighlight: "твой старт в будущее",
+      titleSuffix: "с искусственным интеллектом",
+      subtitle:
+        "Развиваем детей 8+ лет через практику с ИИ-инструментами, креативность и современные цифровые навыки",
+      primaryAction: "Попробовать бесплатно",
+      secondaryAction: "Узнать больше",
+      features: ["Мини-группы до 6 детей", "100% практические занятия", "Реальные проекты с ИИ"],
+    },
+    about: {
+      heading: "О школе",
+      highlight: "Startum Kids",
+      description:
+        "Мы создали уникальную образовательную среду, где дети изучают будущее уже сегодня. Наша миссия — развивать детей через практику с ИИ-инструментами, формируя креативность и цифровые навыки XXI века.",
+      cards: [
+        {
+          title: "Наша цель",
+          description: "Подготовить детей к будущему, где ИИ станет неотъемлемой частью жизни и работы",
+        },
+        {
+          title: "Наш подход",
+          description: "Обучение в мини-группах с индивидуальным подходом к каждому ребенку",
+        },
+        {
+          title: "Наш результат",
+          description: "Уверенные в себе дети, готовые творить и создавать с помощью современных технологий",
+        },
+      ],
+    },
+    whyImportant: {
+      heading: "Почему это",
+      highlight: "важно",
+      description: "В мире, где ИИ меняет все сферы жизни, важно дать детям преимущество уже сегодня",
+      benefits: [
+        {
+          title: "Навыки будущего",
+          description: "Изучение ИИ-инструментов, которые будут востребованы в ближайшие 10-20 лет",
+        },
+        {
+          title: "Креативность",
+          description: "Развитие творческого мышления через создание уникальных проектов с ИИ",
+        },
+        {
+          title: "Работа с технологиями",
+          description: "Практические навыки использования современных цифровых инструментов",
+        },
+        {
+          title: "Уверенность в себе",
+          description: "Повышение самооценки через достижение реальных результатов в проектах",
+        },
+      ],
+    },
+    programs: {
+      heading: "Наши",
+      highlight: "программы",
+      description: "Практические курсы, где дети создают реальные проекты с помощью ИИ-инструментов",
+      items: [
+        {
+          title: "Создай персонажа с ИИ",
+          description: "Дети учатся создавать уникальных персонажей с помощью ИИ-генераторов изображений",
+          duration: "4 недели",
+          age: "8-12 лет",
+          level: "Начинающий",
+        },
+        {
+          title: "Мультфильмы с ИИ",
+          description: "Создание коротких анимационных роликов с использованием ИИ-инструментов",
+          duration: "6 недель",
+          age: "10-14 лет",
+          level: "Продвинутый",
+        },
+        {
+          title: "ИИ-помощник в учёбе",
+          description: "Изучаем, как ИИ может помочь в выполнении домашних заданий и изучении новых тем",
+          duration: "3 недели",
+          age: "8-16 лет",
+          level: "Для всех",
+        },
+      ],
+      cta: "Записаться на курс",
+    },
+    format: {
+      heading: "Формат",
+      highlight: "обучения",
+      description: "Современный подход к образованию с фокусом на практические результаты",
+      features: [
+        {
+          title: "Мини-группы",
+          description: "До 6 детей в группе для максимального внимания каждому ученику",
+        },
+        {
+          title: "Практика",
+          description: "100% практических занятий с реальными ИИ-инструментами",
+        },
+        {
+          title: "Результат",
+          description: "Каждый ребенок создает собственный проект к концу курса",
+        },
+      ],
+    },
+    testimonials: {
+      heading: "Что говорят",
+      highlight: "родители",
+      description: "Отзывы семей, которые уже оценили качество нашего обучения",
+      entries: [
+        {
+          name: "Анна Петрова",
+          role: "Мама Максима, 10 лет",
+          content:
+            "Максим в восторге от занятий! Теперь он создает своих персонажей и даже помогает мне с презентациями для работы. Спасибо Startum Kids за такой современный подход к обучению.",
+          rating: 5,
+        },
+        {
+          name: "Дмитрий Козлов",
+          role: "Папа Софии, 12 лет",
+          content:
+            "София всегда была творческой, но здесь она научилась воплощать свои идеи с помощью ИИ. Теперь она мечтает стать дизайнером и уже создает потрясающие проекты.",
+          rating: 5,
+        },
+        {
+          name: "Елена Смирнова",
+          role: "Мама Артема, 9 лет",
+          content:
+            "Артем стал более уверенным в себе и начал интересоваться технологиями. Преподаватели умеют найти подход к каждому ребенку. Очень рекомендую!",
+          rating: 5,
+        },
+      ],
+    },
+    cta: {
+      headingPrefix: "Startum Kids",
+      headingHighlight: "—",
+      headingSuffix: "начни путь в будущее уже сегодня",
+      description:
+        "Дай своему ребенку преимущество в мире технологий. Запишись на бесплатное пробное занятие и убедись в эффективности нашего подхода.",
+      primaryAction: "Записаться на пробное занятие",
+      secondaryAction: "Задать вопрос",
+      highlights: ["Бесплатное пробное занятие", "Без долгосрочных обязательств", "Индивидуальный подход"],
+    },
+    footer: {
+      description:
+        "Современная мини-школа для детей 8+ лет. Развиваем креативность и цифровые навыки через практику с искусственным интеллектом.",
+      quickLinksHeading: "Быстрые ссылки",
+      quickLinks: {
+        about: "О школе",
+        programs: "Программы",
+        advantages: "Преимущества",
+        schedule: "Расписание",
+        pricing: "Цены",
+      },
+      contactsHeading: "Контакты",
+      phone: "+7 (999) 123-45-67",
+      email: "info@startumkids.ru",
+      address: "г. Москва, ул. Инновационная, д. 42",
+      copyright: "© 2025 Startum Kids. Все права защищены.",
+      privacy: "Политика конфиденциальности",
+      terms: "Пользовательское соглашение",
+    },
+  },
+  en: {
+    metadata: {
+      title: "Startum Kids — your launch into the future with AI",
+      description:
+        "A modern micro-school for children 8+. We develop creativity and digital skills through hands-on work with artificial intelligence.",
+    },
+    header: {
+      brandInitials: "SK",
+      brandName: "Startum Kids",
+      nav: {
+        about: "About",
+        programs: "Programs",
+        advantages: "Benefits",
+        contacts: "Contacts",
+      },
+      cta: "Enroll",
+    },
+    hero: {
+      imageAlt: "Startum Kids learning robot",
+      titlePrefix: "Startum Kids —",
+      titleHighlight: "your launch into the future",
+      titleSuffix: "with artificial intelligence",
+      subtitle:
+        "We help kids 8+ grow through hands-on practice with AI tools, creativity, and modern digital skills",
+      primaryAction: "Try for free",
+      secondaryAction: "Learn more",
+      features: ["Mini-groups of up to 6 kids", "100% hands-on sessions", "Real projects with AI"],
+    },
+    about: {
+      heading: "About the school",
+      highlight: "Startum Kids",
+      description:
+        "We created a unique learning environment where children explore the future today. Our mission is to nurture kids through practice with AI tools, building creativity and 21st century digital skills.",
+      cards: [
+        {
+          title: "Our goal",
+          description: "Prepare children for a future where AI is part of everyday life and work",
+        },
+        {
+          title: "Our approach",
+          description: "Learning in mini-groups with an individual approach to every child",
+        },
+        {
+          title: "Our result",
+          description: "Confident kids ready to create with modern technology",
+        },
+      ],
+    },
+    whyImportant: {
+      heading: "Why it",
+      highlight: "matters",
+      description: "In a world transformed by AI, it's vital to give children an advantage today",
+      benefits: [
+        {
+          title: "Future skills",
+          description: "Learning AI tools that will be in demand over the next 10–20 years",
+        },
+        {
+          title: "Creativity",
+          description: "Developing creative thinking through unique AI-powered projects",
+        },
+        {
+          title: "Tech fluency",
+          description: "Practical experience with modern digital instruments",
+        },
+        {
+          title: "Confidence",
+          description: "Boosting self-esteem by achieving real project outcomes",
+        },
+      ],
+    },
+    programs: {
+      heading: "Our",
+      highlight: "programs",
+      description: "Hands-on courses where kids build real projects with AI tools",
+      items: [
+        {
+          title: "Create a character with AI",
+          description: "Kids learn to design unique characters using AI image generators",
+          duration: "4 weeks",
+          age: "Ages 8–12",
+          level: "Beginner",
+        },
+        {
+          title: "AI-powered cartoons",
+          description: "Produce short animated videos with the help of AI tools",
+          duration: "6 weeks",
+          age: "Ages 10–14",
+          level: "Advanced",
+        },
+        {
+          title: "AI study assistant",
+          description: "Discover how AI can support homework and exploring new topics",
+          duration: "3 weeks",
+          age: "Ages 8–16",
+          level: "All levels",
+        },
+      ],
+      cta: "Join the course",
+    },
+    format: {
+      heading: "Learning",
+      highlight: "format",
+      description: "A modern education approach focused on practical results",
+      features: [
+        {
+          title: "Mini-groups",
+          description: "Up to 6 children per group for maximum attention",
+        },
+        {
+          title: "Practice",
+          description: "100% practical sessions with real AI tools",
+        },
+        {
+          title: "Outcome",
+          description: "Every child completes a personal project by the end of the course",
+        },
+      ],
+    },
+    testimonials: {
+      heading: "What parents",
+      highlight: "say",
+      description: "Feedback from families who have already experienced our school",
+      entries: [
+        {
+          name: "Anna Petrova",
+          role: "Maxim's mom, 10 y.o.",
+          content:
+            "Maxim is thrilled with the classes! Now he creates his own characters and even helps me with work presentations. Thank you, Startum Kids, for such a modern approach to learning.",
+          rating: 5,
+        },
+        {
+          name: "Dmitry Kozlov",
+          role: "Sophia's dad, 12 y.o.",
+          content:
+            "Sophia has always been creative, but here she learned to bring ideas to life with AI. She now dreams of becoming a designer and already makes stunning projects.",
+          rating: 5,
+        },
+        {
+          name: "Elena Smirnova",
+          role: "Artem's mom, 9 y.o.",
+          content:
+            "Artem became more confident and started exploring technology. The teachers find an approach to every child. Highly recommend!",
+          rating: 5,
+        },
+      ],
+    },
+    cta: {
+      headingPrefix: "Startum Kids",
+      headingHighlight: "—",
+      headingSuffix: "start the journey into the future today",
+      description:
+        "Give your child an edge in a tech-driven world. Book a free trial lesson and see the impact for yourself.",
+      primaryAction: "Book a trial lesson",
+      secondaryAction: "Ask a question",
+      highlights: ["Free trial lesson", "No long-term commitments", "Individual approach"],
+    },
+    footer: {
+      description:
+        "A modern micro-school for children 8+. We foster creativity and digital skills through hands-on AI practice.",
+      quickLinksHeading: "Quick links",
+      quickLinks: {
+        about: "About",
+        programs: "Programs",
+        advantages: "Benefits",
+        schedule: "Schedule",
+        pricing: "Pricing",
+      },
+      contactsHeading: "Contacts",
+      phone: "+7 (999) 123-45-67",
+      email: "info@startumkids.ru",
+      address: "Moscow, Innovatsionnaya St. 42",
+      copyright: "© 2025 Startum Kids. All rights reserved.",
+      privacy: "Privacy policy",
+      terms: "Terms of use",
+    },
+  },
+  kk: {
+    metadata: {
+      title: "Startum Kids — жасанды интеллектпен болашаққа жол",
+      description:
+        "8+ жастағы балаларға арналған заманауи мини-мектеп. Біз шығармашылық пен цифрлық дағдыларды ЖИ құралдарымен тәжірибе арқылы дамытамыз.",
+    },
+    header: {
+      brandInitials: "SK",
+      brandName: "Startum Kids",
+      nav: {
+        about: "Мектеп туралы",
+        programs: "Бағдарламалар",
+        advantages: "Артықшылықтар",
+        contacts: "Байланыс",
+      },
+      cta: "Тіркелу",
+    },
+    hero: {
+      imageAlt: "Startum Kids оқу роботы",
+      titlePrefix: "Startum Kids —",
+      titleHighlight: "болашаққа бастайтын жол",
+      titleSuffix: "жасанды интеллектпен",
+      subtitle:
+        "8+ жастағы балаларды ЖИ құралдарымен тәжірибе, шығармашылық және заманауи цифрлық дағдылар арқылы дамытамыз",
+      primaryAction: "Тегін көру",
+      secondaryAction: "Толығырақ",
+      features: ["6 балаға дейінгі мини-топтар", "100% тәжірибелік сабақтар", "ЖИ-мен нақты жобалар"],
+    },
+    about: {
+      heading: "Мектеп туралы",
+      highlight: "Startum Kids",
+      description:
+        "Біз балалар бүгіннің өзінде болашақты зерттейтін ерекше білім беру ортасын құрдық. Миссиямыз — ЖИ құралдарымен тәжірибе арқылы балалардың шығармашылығы мен XXI ғасырдың цифрлық дағдыларын дамыту.",
+      cards: [
+        {
+          title: "Мақсатымыз",
+          description: "ЖИ өмір мен жұмыстың ажырамас бөлігі болатын болашаққа балаларды дайындау",
+        },
+        {
+          title: "Тәсіліміз",
+          description: "Әр балаға жеке көңіл бөлу үшін мини-топтарда оқыту",
+        },
+        {
+          title: "Нәтижеміз",
+          description: "Заманауи технологиялармен жасай алатын, өзіне сенімді балалар",
+        },
+      ],
+    },
+    whyImportant: {
+      heading: "Неліктен бұл",
+      highlight: "маңызды",
+      description: "ЖИ өмірдің барлық саласын өзгертіп жатқанда, балаларға бүгіннен бастап артықшылық беру қажет",
+      benefits: [
+        {
+          title: "Болашақ дағдылары",
+          description: "Алдағы 10–20 жылда сұранысқа ие болатын ЖИ құралдарын меңгеру",
+        },
+        {
+          title: "Шығармашылық",
+          description: "ЖИ көмегімен бірегей жобаларды жасап, шығармашылық ойлауды дамыту",
+        },
+        {
+          title: "Технологияларды меңгеру",
+          description: "Заманауи цифрлық құралдарды қолданудың практикалық дағдылары",
+        },
+        {
+          title: "Өзіндік сенім",
+          description: "Нақты жобалық нәтижелер арқылы өзін-өзі бағалауды арттыру",
+        },
+      ],
+    },
+    programs: {
+      heading: "Біздің",
+      highlight: "бағдарламалар",
+      description: "Балалар ЖИ құралдарының көмегімен нақты жобалар жасайтын тәжірибелік курстар",
+      items: [
+        {
+          title: "ЖИ арқылы кейіпкер жаса",
+          description: "Балалар ЖИ сурет генераторларын пайдаланып ерекше кейіпкерлер құруды үйренеді",
+          duration: "4 апта",
+          age: "8–12 жас",
+          level: "Бастапқы",
+        },
+        {
+          title: "ЖИ мультфильмдері",
+          description: "ЖИ құралдарын қолданып қысқа анимациялық роликтер жасау",
+          duration: "6 апта",
+          age: "10–14 жас",
+          level: "Жетілдірілген",
+        },
+        {
+          title: "Оқудағы ЖИ көмекшісі",
+          description: "ЖИ үй тапсырмасын орындауға және жаңа тақырыптарды зерттеуге қалай көмектесетінін үйренеміз",
+          duration: "3 апта",
+          age: "8–16 жас",
+          level: "Барлығына",
+        },
+      ],
+      cta: "Курсқа жазылу",
+    },
+    format: {
+      heading: "Оқыту",
+      highlight: "форматы",
+      description: "Практикалық нәтижелерге бағытталған заманауи білім беру тәсілі",
+      features: [
+        {
+          title: "Мини-топтар",
+          description: "Әр оқушыға барынша көңіл бөлу үшін топта 6 балаға дейін",
+        },
+        {
+          title: "Тәжірибе",
+          description: "Нағыз ЖИ құралдарымен 100% практикалық сабақтар",
+        },
+        {
+          title: "Нәтиже",
+          description: "Курс соңында әр бала өз жобасын аяқтайды",
+        },
+      ],
+    },
+    testimonials: {
+      heading: "Ата-аналар",
+      highlight: "пікірі",
+      description: "Біздің оқыту сапасын бағалаған отбасылардың пікірлері",
+      entries: [
+        {
+          name: "Анна Петрова",
+          role: "Максимнің анасы, 10 жаста",
+          content:
+            "Максим сабақтарға қуана қатысады! Енді ол өз кейіпкерлерін жасап, маған да жұмыстағы презентацияларға көмектеседі. Заманауи тәсіл үшін Startum Kids-ке рахмет.",
+          rating: 5,
+        },
+        {
+          name: "Дмитрий Козлов",
+          role: "Софияның әкесі, 12 жаста",
+          content:
+            "София әрдайым шығармашыл болатын, бірақ мұнда ол идеяларын ЖИ арқылы жүзеге асыруды үйренді. Енді дизайнер болуды армандайды және керемет жобалар жасайды.",
+          rating: 5,
+        },
+        {
+          name: "Елена Смирнова",
+          role: "Артемнің анасы, 9 жаста",
+          content:
+            "Артем өзіне сенімді болып, технологияға қызыға бастады. Мұғалімдер әр балаға жол таба біледі. Ұсынатын боламын!",
+          rating: 5,
+        },
+      ],
+    },
+    cta: {
+      headingPrefix: "Startum Kids",
+      headingHighlight: "—",
+      headingSuffix: "болашаққа жолды бүгін баста",
+      description:
+        "Балаңызға технологиялар әлемінде артықшылық беріңіз. Тегін сынақ сабағына жазылып, біздің тәсілдің тиімділігіне көз жеткізіңіз.",
+      primaryAction: "Сынақ сабағына жазылу",
+      secondaryAction: "Сұрақ қою",
+      highlights: ["Тегін сынақ сабағы", "Ұзақ мерзімді міндеттемесіз", "Жеке тәсіл"],
+    },
+    footer: {
+      description:
+        "8+ жастағы балаларға арналған заманауи мини-мектеп. ЖИ-пен тәжірибе арқылы шығармашылық пен цифрлық дағдыларды дамытамыз.",
+      quickLinksHeading: "Жылдам сілтемелер",
+      quickLinks: {
+        about: "Мектеп туралы",
+        programs: "Бағдарламалар",
+        advantages: "Артықшылықтар",
+        schedule: "Кесте",
+        pricing: "Баға",
+      },
+      contactsHeading: "Байланыс",
+      phone: "+7 (999) 123-45-67",
+      email: "info@startumkids.ru",
+      address: "Мәскеу, Инновациялық көш., 42",
+      copyright: "© 2025 Startum Kids. Барлық құқықтар қорғалған.",
+      privacy: "Құпиялылық саясаты",
+      terms: "Пайдаланушы келісімі",
+    },
+  },
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## Summary
- add a language provider and comprehensive translations for Russian, English, and Kazakh content
- implement a language switcher in the header and wire all sections to translated copy across the site

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d90162c198832bae24808c6537d28a